### PR TITLE
security: Fix vulnerability by switching websocket library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,12 @@ derive_builder = "0.12"
 directories = { version = "4.0", optional = true }
 log = "0.4"
 rand = "0.8"
+futures = "0.3.25"
+futures-util = "0.3.25"
+tokio-tungstenite = "0.18.0"
+tungstenite = "0.18.0"
+tokio = { version = "*", no-default-features = true, features = ["rt", "sync"] }
+url = "*"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -23,7 +29,6 @@ tempfile = "3"
 thiserror = '1'
 ureq = { version = "2.5", optional = true }
 walkdir = { version = "2", optional = true }
-websocket = { version = "0.26", default_features = false, features = ["sync"] }
 which = "4.0"
 zip = { version = "0.6.3", optional = true }
 
@@ -33,7 +38,7 @@ winreg = "0.10"
 
 [dev-dependencies]
 chrono = { version = "0.4", default_features = false, features = ["clock"] }
-env_logger = "0.10"
+env_logger = "0.9"
 filepath = "0.1.1"
 jpeg-decoder = { version = "0.3", default_features = false }
 png = { version = "0.17" }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -12,7 +12,7 @@ pub use process::{LaunchOptions, LaunchOptionsBuilder, DEFAULT_ARGS};
 pub use tab::Tab;
 pub use transport::ConnectionClosed;
 use transport::Transport;
-use websocket::url::Url;
+use url::Url;
 use which::which;
 
 use crate::protocol::cdp::{types::Event, types::Method, Browser as B, Target, CSS, DOM};

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -16,7 +16,7 @@ use rand::seq::SliceRandom;
 use rand::thread_rng;
 use regex::Regex;
 use thiserror::Error;
-use websocket::url::Url;
+use url::Url;
 #[cfg(windows)]
 use winreg::{enums::HKEY_LOCAL_MACHINE, RegKey};
 

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -15,7 +15,7 @@ use log::{error, info, trace, warn};
 
 use waiting_call_registry::WaitingCallRegistry;
 use web_socket_connection::WebSocketConnection;
-use websocket::url::Url;
+use url::Url;
 
 use crate::protocol::cdp::{types::Event, types::Method, Target};
 

--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -1,26 +1,25 @@
 use std::sync::mpsc;
-use std::sync::Mutex;
+use std::sync::Arc;
 
 use anyhow::Result;
-use log::{debug, info, trace, warn};
-use websocket::client::sync::Client;
-use websocket::stream::sync::TcpStream;
-use websocket::url::Url;
-use websocket::WebSocketError;
-use websocket::{ClientBuilder, OwnedMessage};
+use futures::{
+    stream::{SplitSink, SplitStream},
+    SinkExt,
+};
+use futures_util::stream::StreamExt;
+use log::*;
+use tokio::{net::TcpStream, runtime::Runtime, sync::Mutex};
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tungstenite::client::IntoClientRequest;
+use url::Url;
 
 use crate::types::{parse_raw_message, Message};
 
+#[derive(Debug)]
 pub struct WebSocketConnection {
-    sender: Mutex<websocket::sender::Writer<TcpStream>>,
+    sender: Arc<Mutex<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tungstenite::Message>>>,
+    runtime: Arc<Runtime>,
     process_id: Option<u32>,
-}
-
-// TODO websocket::sender::Writer is not :Debug...
-impl std::fmt::Debug for WebSocketConnection {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        write!(f, "WebSocketConnection {{}}")
-    }
 }
 
 impl WebSocketConnection {
@@ -29,17 +28,36 @@ impl WebSocketConnection {
         process_id: Option<u32>,
         messages_tx: mpsc::Sender<Message>,
     ) -> Result<Self> {
-        let connection = Self::websocket_connection(ws_url)?;
-        let (websocket_receiver, sender) = connection.split()?;
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?,
+        );
 
+        let connection: Result<_> = runtime.block_on(async {
+            let (stream, _) = connect_async(ws_url.to_string().into_client_request()?).await?;
+
+            debug!("Successfully connected to WebSocket: {}", ws_url);
+
+            Ok(stream)
+        });
+
+        let (sender, recv) = connection?.split();
+
+        let clone_rt = runtime.clone();
         std::thread::spawn(move || {
             trace!("Starting msg dispatching loop");
-            Self::dispatch_incoming_messages(websocket_receiver, messages_tx, process_id);
+            clone_rt.block_on(Self::dispatch_incoming_messages(
+                recv,
+                messages_tx,
+                process_id,
+            ));
             trace!("Quit loop msg dispatching loop");
         });
 
         Ok(Self {
-            sender: Mutex::new(sender),
+            sender: Arc::new(Mutex::new(sender)),
+            runtime,
             process_id,
         })
     }
@@ -49,27 +67,27 @@ impl WebSocketConnection {
             "Shutting down WebSocket connection for Chrome {:?}",
             self.process_id
         );
-        if self.sender.lock().unwrap().shutdown_all().is_err() {
-            debug!(
-                "Couldn't shut down WS connection for Chrome {:?}",
-                self.process_id
-            );
-        }
+
+        self.runtime.block_on(async {
+            if self.sender.lock().await.close().await.is_err() {
+                debug!(
+                    "Couldn't shut down WS connection for Chrome {:?}",
+                    self.process_id
+                );
+            }
+        });
     }
 
-    fn dispatch_incoming_messages(
-        mut receiver: websocket::receiver::Reader<TcpStream>,
+    async fn dispatch_incoming_messages(
+        mut receiver: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
         messages_tx: mpsc::Sender<Message>,
         process_id: Option<u32>,
     ) {
-        for ws_message in receiver.incoming_messages() {
+        loop {
+            let ws_message = receiver.next().await;
             match ws_message {
-                Err(error) => match error {
-                    WebSocketError::NoDataAvailable => {
-                        debug!("WS Error Chrome #{:?}: {}", process_id, error);
-                        break;
-                    }
-                    WebSocketError::IoError(err) => {
+                Some(Err(error)) => match error {
+                    tungstenite::Error::Io(err) => {
                         debug!("WS IO Error for Chrome #{:?}: {}", process_id, err);
                         break;
                     }
@@ -78,8 +96,8 @@ impl WebSocketConnection {
                         process_id, error
                     ),
                 },
-                Ok(message) => {
-                    if let OwnedMessage::Text(message_string) = message {
+                Some(Ok(message)) => {
+                    if let tungstenite::Message::Text(message_string) = message {
                         if let Ok(message) = parse_raw_message(&message_string) {
                             if messages_tx.send(message).is_err() {
                                 break;
@@ -94,28 +112,23 @@ impl WebSocketConnection {
                         panic!("Got a weird message: {:?}", message);
                     }
                 }
+                // Keep waiting for an event in case nothing was fetched yet.
+                None => (),
             }
         }
 
         info!("Sending shutdown message to message handling loop");
         if messages_tx.send(Message::ConnectionShutdown).is_err() {
-            warn!("Couldn't send message to transport loop telling it to shut down");
+            warn!("Couldn't send message to transport loop telling it to shut down")
         }
     }
 
-    pub fn websocket_connection(ws_url: &Url) -> Result<Client<TcpStream>> {
-        let client = ClientBuilder::from_url(ws_url).connect_insecure()?;
-
-        debug!("Successfully connected to WebSocket: {}", ws_url);
-
-        Ok(client)
-    }
-
     pub fn send_message(&self, message_text: &str) -> Result<()> {
-        let message = websocket::Message::text(message_text);
-        let mut sender = self.sender.lock().unwrap();
-        sender.send_message(&message)?;
-        Ok(())
+        let message = tungstenite::Message::text(message_text);
+
+        Ok(self
+            .runtime
+            .block_on(async { self.sender.lock().await.send(message).await })?)
     }
 }
 


### PR DESCRIPTION
Currently this crate uses the `websocket` crate, that has a dependency on a hyper version that is subject to a security vulnerability. This change switches the implementation to the `tokio-tungstenite` websocket library, which exposes an async interface. In order to fit the async interface with the current sync interface, [async-bridging](https://tokio.rs/tokio/topics/bridging) is used.

This fixes #322. 
Related issues: #346, #341