### PR TITLE
Updated Chrome revision and added Mac_Arm chrome installation

### DIFF
--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -18,7 +18,7 @@ use walkdir::WalkDir;
 #[cfg(not(target_os = "macos"))]
 use zip;
 
-pub const CUR_REV: &str = "634997";
+pub const CUR_REV: &str = "1095492";
 
 const APP_NAME: &str = "headless-chrome";
 const DEFAULT_HOST: &str = "https://storage.googleapis.com";

--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -25,7 +25,9 @@ const DEFAULT_HOST: &str = "https://storage.googleapis.com";
 
 #[cfg(target_os = "linux")]
 const PLATFORM: &str = "linux";
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const PLATFORM: &str = "mac_arm";
+#[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
 const PLATFORM: &str = "mac";
 #[cfg(windows)]
 const PLATFORM: &str = "win";
@@ -346,10 +348,20 @@ where
         ))
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
     {
         Ok(format!(
             "{}/chromium-browser-snapshots/Mac/{}/{}.zip",
+            DEFAULT_HOST,
+            revision.as_ref(),
+            archive_name(revision.as_ref())?
+        ))
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        Ok(format!(
+            "{}/chromium-browser-snapshots/Mac_Arm/{}/{}.zip",
             DEFAULT_HOST,
             revision.as_ref(),
             archive_name(revision.as_ref())?


### PR DESCRIPTION
1. fetch revision 1095492 is the same as the current [chrome revision of puppeteer](https://github.com/puppeteer/puppeteer/blob/b14628738010ab80960a1834c2db85bbe1223bac/packages/puppeteer-core/src/revisions.ts#L21).

2. Added a dependency to install the Chrome browser on Arm-based macOS.