### PR TITLE
Add derive(Debug) and tracing logging

### DIFF
--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -30,7 +30,7 @@ const PLATFORM: &str = "mac";
 #[cfg(windows)]
 const PLATFORM: &str = "win";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FetcherOptions {
     /// The desired chrome revision.
     ///

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -371,6 +371,8 @@ impl Process {
             .ok_or_else(|| anyhow!("Chrome path required"))?;
 
         info!("Launching Chrome binary at {:?}", &path);
+        trace!("with CLI arguments: {:?}", args);
+
         let mut command = Command::new(path);
 
         if let Some(process_envs) = launch_options.process_envs.clone() {

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -77,7 +77,7 @@ impl Drop for TemporaryProcess {
 
 /// Represents the way in which Chrome is run. By default it will search for a Chrome
 /// binary on the system, use an available port for debugging, and start in headless mode.
-#[derive(Builder)]
+#[derive(Debug, Builder)]
 pub struct LaunchOptions<'a> {
     /// Determines whether to run headless version of the browser. Defaults to true.
     #[builder(default = "true")]


### PR DESCRIPTION
Small improvement to add derive(Debug) to 2 structs and adding tracing logging for the CLI options used to start the headless browser.

With the old version I had the issue of `print_to_pdf` always working sequentially even though I used it with futures and I was trying to make multiple PDF at the same time. Will test if this issue has persisted.