### PR TITLE
Added installation latest version of chrome and refactored fetcher

### DIFF
--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -35,7 +35,7 @@ const PLATFORM: &str = "win";
 #[derive(Clone, Debug)]
 pub enum Revision {
     Specific(String),
-    Latest
+    Latest,
 }
 
 #[derive(Clone, Debug)]
@@ -415,7 +415,6 @@ fn archive_name<R: AsRef<str>>(revision: R) -> Result<&'static str> {
         }
     }
 }
-
 
 // Returns the latest chrome revision for the current platform.
 // This function will panic on unsupported platforms.

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -26,6 +26,9 @@ pub use B::GetVersionReturnObject;
 #[cfg(feature = "fetch")]
 pub use fetcher::FetcherOptions;
 
+#[cfg(feature = "fetch")]
+pub use fetcher::Revision;
+
 pub mod context;
 #[cfg(feature = "fetch")]
 mod fetcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ pub use browser::{
 #[cfg(feature = "fetch")]
 pub use browser::FetcherOptions;
 
+#[cfg(feature = "fetch")]
+pub use browser::Revision;
+
 pub mod browser;
 pub mod protocol;
 pub mod types;


### PR DESCRIPTION
Fixed fetcher as discussed in 
https://github.com/rust-headless-chrome/rust-headless-chrome/pull/374#discussion_r1112055894 and https://github.com/rust-headless-chrome/rust-headless-chrome/pull/374#issuecomment-1435509578

Now Revision::Latest gets the revision and installs the latest version of Chrome on that platform.

e.g
```rust
// let revision = headless_chrome::Revision::Specific("634997".into());
let revision = headless_chrome::Revision::Latest;
let fetcher_options = headless_chrome::FetcherOptions::default()
    .with_revision(revision);

let launch_options = headless_chrome::LaunchOptionsBuilder::default()
    .fetcher_options(fetcher_options)
    .build()?;

let browser = Browser::new(launch_options)?;
```