### PR TITLE
Make `--enable-logging` not hard coded

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -87,6 +87,12 @@ pub struct LaunchOptions<'a> {
     #[builder(default = "true")]
     pub sandbox: bool,
 
+    /// Determines whether to run the browser with logging enabled
+    /// (this can cause unwanted new shell window in Windows 10 and above).
+    /// Check <https://github.com/rust-headless-chrome/rust-headless-chrome/issues/371>
+    #[builder(default = "false")]
+    pub enable_logging: bool,
+
     /// Launch the browser with a specific window width and height.
     #[builder(default = "None")]
     pub window_size: Option<(u32, u32)>,
@@ -159,6 +165,7 @@ impl<'a> Default for LaunchOptions<'a> {
         LaunchOptions {
             headless: true,
             sandbox: true,
+            enable_logging: false,
             idle_browser_timeout: Duration::from_secs(30),
             window_size: None,
             path: None,
@@ -310,7 +317,6 @@ impl Process {
         let mut args = vec![
             port_option.as_str(),
             "--disable-gpu",
-            "--enable-logging",
             "--verbose",
             "--log-level=0",
             "--no-first-run",
@@ -341,6 +347,10 @@ impl Process {
 
         if launch_options.ignore_certificate_errors {
             args.extend(["--ignore-certificate-errors"]);
+        }
+
+        if launch_options.enable_logging {
+            args.extend(["--enable-logging"]);
         }
 
         let proxy_server_option = if let Some(proxy_server) = launch_options.proxy_server {


### PR DESCRIPTION
Resolve https://github.com/rust-headless-chrome/rust-headless-chrome/issues/371 according to the idea from @vootooguru and verification from @ameleumit

I add `enable_logging` to LaunchOptions and make it disabled by default.