### PR TITLE
better error for click on element which is not visible

### DIFF
--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -515,7 +515,7 @@ impl<'a> Element<'a> {
                 object_id: None,
             })
             .map(|quad| {
-                let raw_quad = quad.quads.first().except("tried to get the midpoint of an element which is not visible");
+                let raw_quad = quad.quads.first().expect("tried to get the midpoint of an element which is not visible");
                 let input_quad = ElementQuad::from_raw_points(raw_quad);
 
                 (input_quad.bottom_right + input_quad.top_left) / 2.0

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -515,7 +515,7 @@ impl<'a> Element<'a> {
                 object_id: None,
             })
             .map(|quad| {
-                let raw_quad = quad.quads.first().unwrap();
+                let raw_quad = quad.quads.first().except("tried to get the midpoint of an element which is not visible");
                 let input_quad = ElementQuad::from_raw_points(raw_quad);
 
                 (input_quad.bottom_right + input_quad.top_left) / 2.0


### PR DESCRIPTION
This is in response to [#364](https://github.com/rust-headless-chrome/rust-headless-chrome/issues/364)
to get a better error in the case we try to click on an element which is hidden / not visible.