### PR TITLE
Disable automatic tab creation on launching chrome

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -164,11 +164,7 @@ impl Browser {
         // so we get events like 'targetCreated' and 'targetDestroyed'
         trace!("Calling set discover");
         browser.call_method(SetDiscoverTargets { discover: true })?;
-
-        let tab = browser.new_tab()?;
-
-        tab.call_method(DOM::Enable(None))?;
-        tab.call_method(CSS::Enable(None))?;
+        
         Ok(browser)
     }
 


### PR DESCRIPTION
It is useful to launch chrome directly with `<url>` (or `--app=<url>`) as argument, if you use headful browser.
Not opening empty tab is essential for [simple neovim plugin](https://github.com/dimchee/prochrome.nvim) I am developing. 
It would be nice too if `--app=<url>` option was part of `LaunchOptions`.
I have seen that others had same issue as me, so this fixes #392.