### PR TITLE
Fixes wrong error message when running as root in sandbox mode

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -273,7 +273,7 @@ impl Process {
             attempts += 1;
         }
 
-        let mut child = process.0.borrow_mut();
+        let child = process.0.borrow_mut();
         child.stderr = None;
 
         Ok(Self {

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -50,6 +50,8 @@ enum ChromeLaunchError {
     NoAvailablePorts,
     #[error("The chosen debugging port is already in use")]
     DebugPortInUse,
+    #[error("You need to set the sandbox(false) option when running as root")]
+    RunningAsRootWithoutNoSandbox,
 }
 
 #[cfg(windows)]
@@ -409,6 +411,7 @@ impl Process {
         R: Read,
     {
         let port_taken_re = Regex::new(r"ERROR.*bind\(\)")?;
+        let root_sandbox = "Running as root without --no-sandbox is not supported";
 
         let re = Regex::new(r"listening on (.*/devtools/browser/.*)$")?;
 
@@ -421,6 +424,10 @@ impl Process {
         for line in reader.lines() {
             let chrome_output = line?;
             trace!("Chrome output: {}", chrome_output);
+
+            if chrome_output.contains(root_sandbox) {
+                return Err(ChromeLaunchError::RunningAsRootWithoutNoSandbox {}.into());
+            }
 
             if port_taken_re.is_match(&chrome_output) {
                 return Err(ChromeLaunchError::DebugPortInUse {}.into());


### PR DESCRIPTION
When running as root the error reported is misleading:

```
There are no available ports between 8000 and 9000 for debugging
```

This commit fixes this and reports the proper (new) error `RunningAsRootWithoutNoSandbox`:

```
You need to set the sandbox(false) option when running as root
```