### PR TITLE
Fix detecting msedge.exe in Windows when Chrome is not found through registry

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -482,12 +482,12 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
         if let Some(path) = get_chrome_path_from_registry() {
             if path.exists() {
                 return Ok(path);
-            } else {
-                for path in &[r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"][..] {
-                    if std::path::Path::new(path).exists() {
-                        return Ok(path.into());
-                    }
-                }
+            }
+        }
+
+        for path in &[r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"][..] {
+            if std::path::Path::new(path).exists() {
+                return Ok(path.into());
             }
         }
     }


### PR DESCRIPTION
I don't have Chrome installed, but Edge exists by default. When I do `println!("{}", headless_chrome::browser::default_executable());`, it tells me "Could not auto detect a chrome executable".

The related msedge.exe detection code seems wrong, because 1) it doesn't use `path` from the enclosing if let, and 2) msedge should be only needed if chrome is not detected, but the current code only does it otherwise.