### PR TITLE
Propagate error of unable to find midpoint upward instead of panicking

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -271,7 +271,7 @@ impl Process {
             attempts += 1;
         }
 
-        let mut child = process.0.borrow_mut();
+        let child = process.0.borrow_mut();
         child.stderr = None;
 
         Ok(Self {

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -494,7 +494,7 @@ impl<'a> Element<'a> {
                 Some(serde_json::from_value(attribute_value)?)
             } else {
                 None
-            }
+            },
         )
     }
 
@@ -527,10 +527,15 @@ impl<'a> Element<'a> {
                 object_id: None,
             })
             .and_then(|quad| {
-                quad.quads.first()
+                quad.quads
+                    .first()
                     .map(|raw_quad| ElementQuad::from_raw_points(raw_quad))
                     .map(|input_quad| (input_quad.bottom_right + input_quad.top_left) / 2.0)
-                    .ok_or_else(|| anyhow::anyhow!("tried to get the midpoint of an element which is not visible"))
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "tried to get the midpoint of an element which is not visible"
+                        )
+                    })
             })
         {
             return Ok(e);

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -526,11 +526,11 @@ impl<'a> Element<'a> {
                 backend_node_id: Some(self.backend_node_id),
                 object_id: None,
             })
-            .map(|quad| {
-                let raw_quad = quad.quads.first().expect("tried to get the midpoint of an element which is not visible");
-                let input_quad = ElementQuad::from_raw_points(raw_quad);
-
-                (input_quad.bottom_right + input_quad.top_left) / 2.0
+            .and_then(|quad| {
+                quad.quads.first()
+                    .map(|raw_quad| ElementQuad::from_raw_points(raw_quad))
+                    .map(|input_quad| (input_quad.bottom_right + input_quad.top_left) / 2.0)
+                    .ok_or_else(|| anyhow::anyhow!("tried to get the midpoint of an element which is not visible"))
             })
         {
             return Ok(e);


### PR DESCRIPTION
It seems sometimes after finding an element, if immediately calling something like `.click()`, we get a panic at unwrapping a `None`. The related code seems to assume this should never happen. Maybe it's a better idea to propagate the error upward.