### PR TITLE
Add get_attribute_value() for Element

### DIFF
--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -486,6 +486,18 @@ impl<'a> Element<'a> {
         Ok(description.attributes)
     }
 
+    pub fn get_attribute_value(&self, attribute_name: &str) -> Result<Option<String>> {
+        let js_fn = format!("function() {{ return this.getAttribute('{attribute_name}'); }}");
+
+        Ok(
+            if let Some(attribute_value) = self.call_js_fn(&js_fn, Vec::new(), true)?.value {
+                Some(serde_json::from_value(attribute_value)?)
+            } else {
+                None
+            }
+        )
+    }
+
     /// Get boxes for this element
     pub fn get_box_model(&self) -> Result<BoxModel> {
         let model = self


### PR DESCRIPTION
Seemingly a quintessential function for an Element object, and there is indeed [people asking for it](https://github.com/rust-headless-chrome/rust-headless-chrome/issues/308), and [chromiumoxide implements it](https://github.com/mattsse/chromiumoxide/blob/939a12664ac6fc85fde92112f80bcafdb3e26421/src/element.rs#L334).