### PR TITLE
ci.yml Also run tests on windows-latest and macos-latest and fix platform specific build errors and warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,21 @@ env:
 
 jobs:
   check:
-    name: cargo clippy && cargo fmt && cargo test
+    name: cargo clippy && cargo fmt && cargo test (linux)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - run: cargo fmt --all -- --check
+      - run: cargo test google.com --all-features --all-targets
+      - run: cargo clippy --all-features --all-targets
+
+  check-win:
+    name: cargo clippy && cargo fmt && cargo test (windows)
+    runs-on: windows-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: cargo clippy --all-features --all-targets
 
   check-win:
-    name: "win: cargo clippy && cargo fmt && cargo test"
+    name: "win: cargo clippy && cargo test"
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -34,12 +34,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - run: cargo fmt --all -- --check
       - run: cargo test google.com --all-features --all-targets
       - run: cargo clippy --all-features --all-targets
 
   check-macos:
-    name: "macos: cargo clippy && cargo fmt && cargo test"
+    name: "macos: cargo clippy && cargo test"
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
@@ -47,6 +46,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - run: cargo fmt --all -- --check
       - run: cargo test google.com --all-features --all-targets
       - run: cargo clippy --all-features --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    name: cargo clippy && cargo fmt && cargo test (linux)
+    name: "ubuntu: cargo clippy && cargo fmt && cargo test"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -26,8 +26,21 @@ jobs:
       - run: cargo clippy --all-features --all-targets
 
   check-win:
-    name: cargo clippy && cargo fmt && cargo test (windows)
+    name: "win: cargo clippy && cargo fmt && cargo test"
     runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - run: cargo fmt --all -- --check
+      - run: cargo test google.com --all-features --all-targets
+      - run: cargo clippy --all-features --all-targets
+
+  check-macos:
+    name: "macos: cargo clippy && cargo fmt && cargo test"
+    runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ureq = { version = "2.5", optional = true }
 walkdir = { version = "2", optional = true }
 tungstenite = "0.20"
 url = "2.3"
-which = "4.0"
+which = "5.0"
 zip = { version = "0.6.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headless_chrome"
-version = "1.0.7"
+version = "1.0.8"
 authors = ["Alistair Roche <alistair@sunburnt.country>"]
 edition = "2021"
 description = "Control Chrome programatically"

--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -232,7 +232,7 @@ impl Fetcher {
     }
 
     #[cfg(target_os = "macos")]
-    fn do_unzip<P: AsRef<Path>>(&self, zip_path: P, extract_path: &Path) -> Result<()> {
+    fn do_unzip<P: AsRef<Path>>(zip_path: P, extract_path: &Path) -> Result<()> {
         let out = std::process::Command::new("unzip")
             .arg(zip_path.as_ref().as_os_str())
             .current_dir(&extract_path)
@@ -409,7 +409,7 @@ fn archive_name<R: AsRef<str>>(revision: R) -> &'static str {
     #[cfg(windows)]
     {
         // Windows archive name changed at r591479.
-        if revision.as_ref().parse::<u32>() > Ok(591_479) {
+        if revision.as_ref().parse::<u32>().ok() > Some(591_479) {
             "chrome-win"
         } else {
             "chrome-win32"

--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -366,7 +366,7 @@ where
             "{}/chromium-browser-snapshots/Mac/{}/{}.zip",
             DEFAULT_HOST,
             revision.as_ref(),
-            archive_name(revision.as_ref())?
+            archive_name(revision.as_ref())
         )
     }
 
@@ -376,7 +376,7 @@ where
             "{}/chromium-browser-snapshots/Mac_Arm/{}/{}.zip",
             DEFAULT_HOST,
             revision.as_ref(),
-            archive_name(revision.as_ref())?
+            archive_name(revision.as_ref())
         )
     }
 
@@ -386,7 +386,7 @@ where
             "{}/chromium-browser-snapshots/Win_x64/{}/{}.zip",
             DEFAULT_HOST,
             revision.as_ref(),
-            archive_name(revision.as_ref())?
+            archive_name(revision.as_ref())
         )
     }
 }
@@ -409,7 +409,7 @@ fn archive_name<R: AsRef<str>>(revision: R) -> &'static str {
     #[cfg(windows)]
     {
         // Windows archive name changed at r591479.
-        if revision.as_ref().parse::<u32>()? > 591_479 {
+        if revision.as_ref().parse::<u32>() > Ok(591_479) {
             "chrome-win"
         } else {
             "chrome-win32"

--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -235,7 +235,7 @@ impl Fetcher {
     fn do_unzip<P: AsRef<Path>>(zip_path: P, extract_path: &Path) -> Result<()> {
         let out = std::process::Command::new("unzip")
             .arg(zip_path.as_ref().as_os_str())
-            .current_dir(&extract_path)
+            .current_dir(extract_path)
             .output()?;
 
         if !out.status.success() {


### PR DESCRIPTION
Currently `rust-headless-chrome` developers mainly develop on Linux systems or don't have Windows systems to test on. Moreover the Github actions also don't run tests for the Windows platform.

Therefore `rust-headless-chrome` may release broken crates that affect Windows or MacOS systems and the bugs might go unnoticed for a release or two.

Such as happend recently in https://github.com/rust-headless-chrome/rust-headless-chrome/issues/427 or https://github.com/mdrokz/auto_generate_cdp/issues/12 And even when patching those it was hard to get the patch right, even when the build didn't even pass a simple compile.

This pull request ads `windows-latest` to `ci.yml`. This will increase build-minutes, but make it immediately obvious if there is a problem building `rust-headless-chrome` for Windows:

![image](https://github.com/rust-headless-chrome/rust-headless-chrome/assets/588533/243d6f9a-5fda-4de6-9988-b0d418daa4dc)
