### PR TITLE
removed audio disable argument

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -328,7 +328,6 @@ impl Process {
             "--verbose",
             "--log-level=0",
             "--no-first-run",
-            "--disable-audio-output",
             data_dir_option.as_str(),
         ];
 


### PR DESCRIPTION
removed audio disable argument in order to play audio in chrome