### PR TITLE
chore: enable ureq proxy-from-env

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 thiserror = "1"
-ureq = { version = "2.5", optional = true }
+ureq = { version = "2.5", optional = true, features = ["proxy-from-env"] }
 walkdir = { version = "2", optional = true }
 tungstenite = "0.21"
 url = "2.3"


### PR DESCRIPTION
Enable the `proxy-from-env` feature in `ureq` for the optional `fetch` feature so that chrome-headless can be downloaded via system proxy.