### PR TITLE
Readme fixes (use regular comments + fixed some links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ browser testing / web crawling use cases, and there are several 'advanced' featu
 - Opening incognito windows
 - [taking screenshots of elements or the entire page](https://docs.rs/headless_chrome/latest/headless_chrome/browser/tab/struct.Tab.html#method.capture_screenshot)
 - [saving pages to PDF](https://docs.rs/headless_chrome/latest/headless_chrome/browser/tab/struct.Tab.html#method.print_to_pdf)
-- ['headful' browsing](https://docs.rs/headless_chrome/latest/headless_chrome/struct.LaunchOptionsBuilder.html#method.headless)
+- ['headful' browsing](https://docs.rs/headless_chrome/latest/headless_chrome/browser/struct.LaunchOptionsBuilder.html#method.headless)
 - automatic downloading of 'known good' Chromium binaries for Linux / Mac / Windows
-- [extension pre-loading](https://docs.rs/headless_chrome/latest/headless_chrome/struct.LaunchOptionsBuilder.html#method.extensions)
+- [extension pre-loading](https://docs.rs/headless_chrome/latest/headless_chrome/browser/struct.LaunchOptionsBuilder.html#method.extensions)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -34,28 +34,28 @@ fn browse_wikipedia() -> Result<(), Box<dyn Error>> {
 
     let tab = browser.new_tab()?;
 
-    /// Navigate to wikipedia
+    // Navigate to wikipedia
     tab.navigate_to("https://www.wikipedia.org")?;
 
-    /// Wait for network/javascript/dom to make the search-box available
-    /// and click it.
+    // Wait for network/javascript/dom to make the search-box available
+    // and click it.
     tab.wait_for_element("input#searchInput")?.click()?;
 
-    /// Type in a query and press `Enter`
+    // Type in a query and press `Enter`
     tab.type_str("WebKit")?.press_key("Enter")?;
 
-    /// We should end up on the WebKit-page once navigated
+    // We should end up on the WebKit-page once navigated
     let elem = tab.wait_for_element("#firstHeading")?;
     assert!(tab.get_url().ends_with("WebKit"));
 
-    /// Take a screenshot of the entire browser window
+    // Take a screenshot of the entire browser window
     let _jpeg_data = tab.capture_screenshot(
         Page::CaptureScreenshotFormatOption::Jpeg,
         None,
         None,
         true)?;
 
-    /// Take a screenshot of just the WebKit-Infobox
+    // Take a screenshot of just the WebKit-Infobox
     let _png_data = tab
         .wait_for_element("#mw-content-text > div > table.infobox.vevent")?
         .capture_screenshot(Page::CaptureScreenshotFormatOption::Png)?;


### PR DESCRIPTION
Those were doc comments instead of regular comments, so the compiler gives a bunch of warnings when you copy paste the example to try it out because there's nothing to document.

Edit: fixed the broken `LaunchOptionsBuilder` links too