### PR TITLE
Save screenshots to disc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,20 @@ fn browse_wikipedia() -> Result<(), Box<dyn Error>> {
     assert!(tab.get_url().ends_with("WebKit"));
 
     /// Take a screenshot of the entire browser window
-    let _jpeg_data = tab.capture_screenshot(
+    let jpeg_data = tab.capture_screenshot(
         Page::CaptureScreenshotFormatOption::Jpeg,
         None,
         None,
         true)?;
+    // Save the screenshot to disc
+    std::fs::write("screenshot.jpeg", jpeg_data)?;
 
     /// Take a screenshot of just the WebKit-Infobox
-    let _png_data = tab
+    let png_data = tab
         .wait_for_element("#mw-content-text > div > table.infobox.vevent")?
         .capture_screenshot(Page::CaptureScreenshotFormatOption::Png)?;
+    // Save the screenshot to disc
+    std::fs::write("screenshot.png", png_data)?;
 
     // Run JavaScript in the page
     let remote_object = elem.call_js_fn(r#"


### PR DESCRIPTION
Hi!

Small docs-only change that explicitly shows that you can simply save the screenshot to disc  using `std::fs::write("screenshot.jpeg", jpeg_data)?;`, it wasn't immediately obvious to me that I could just write the bytes to disc.
