### PR TITLE
[docs] Add links for `Tab.press_key`

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -877,6 +877,10 @@ impl Tab {
         Ok(self)
     }
 
+    /// Press a key on the keyboard, optionally with some modifier keys.
+    /// See [this file](https://github.com/puppeteer/puppeteer/blob/62da2366c65b335751896afbb0206f23c61436f1/lib/USKeyboardLayout.js)
+    /// for a full definition of which strings correspond with which
+    /// keys.
     pub fn press_key_with_modifiers(
         &self,
         key: &str,
@@ -947,6 +951,9 @@ impl Tab {
         Ok(self)
     }
 
+    /// Press a key on the keyboard. See [this file](https://github.com/puppeteer/puppeteer/blob/62da2366c65b335751896afbb0206f23c61436f1/lib/USKeyboardLayout.js)
+    /// for a full definition of which strings correspond with which
+    /// keys.
     pub fn press_key(&self, key: &str) -> Result<&Self> {
         self.press_key_with_modifiers(key, None)
     }


### PR DESCRIPTION
Just a small docs change that links to this file:

https://github.com/puppeteer/puppeteer/blob/62da2366c65b335751896afbb0206f23c61436f1/lib/USKeyboardLayout.js

which seems like it defines the various strings and their keys