### PR TITLE
chore(msrv): set to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "headless_chrome"
 version = "1.0.9"
 authors = ["Alistair Roche <alistair@sunburnt.country>"]
 edition = "2021"
+rust-version = "1.70"
 description = "Control Chrome programatically"
 license = "MIT"
 homepage = "https://github.com/atroche/rust-headless-chrome"


### PR DESCRIPTION
It will be helpful for the down stream crates to know what the minimum supported Rust version (MSRV) for their dependencies so they can decide how to bump their version and when, because it's considered as a breaking change
