### PR TITLE
Updated cargo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "headless_chrome"
 version = "1.0.10"
 authors = ["Alistair Roche <alistair@sunburnt.country>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.78"
 description = "Control Chrome programatically"
 license = "MIT"
 homepage = "https://github.com/rust-headless-chrome/rust-headless-chrome"
@@ -22,12 +22,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 thiserror = "1"
-ureq = { version = "2.5", optional = true, features = ["proxy-from-env"] }
+ureq = { version = "2.9", optional = true, features = ["proxy-from-env"] }
 walkdir = { version = "2", optional = true }
 tungstenite = "0.21.0"
-url = "2.3"
+url = "2.5"
 which = "6.0.1"
-zip = { version = "1.2.1", optional = true }
+zip = { version = "2.1.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"
@@ -35,7 +35,7 @@ winreg = "0.52.0"
 [dev-dependencies]
 chrono = { version = "0.4", default_features = false, features = ["clock"] }
 env_logger = "0.11.3"
-filepath = "0.1.1"
+filepath = "0.1.2"
 jpeg-decoder = { version = "0.3", default_features = false }
 png = { version = "0.17" }
 tiny_http = "0.12"


### PR DESCRIPTION
Updated cargo dependencies and rust version.
Fixes https://github.com/rust-headless-chrome/rust-headless-chrome/issues/485