### PR TITLE
Bugfix: iterator instead of string was printed

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -509,7 +509,10 @@ impl Tab {
             .transport
             .call_method_on_target(self.session_id.clone(), method);
         let result_string = format!("{result:?}");
-        trace!("Got result: {:?}", result_string.chars().take(70));
+        trace!(
+            "Got result: {:?}",
+            result_string.chars().take(70).collect::<String>()
+        );
         result
     }
 


### PR DESCRIPTION
The `trace!` output of `Tab::call_method` was trying to print the first 70 characters of the result of the method call, but it was printing an iterator instead.  As a result, it print much more long log even than the original string despite the intention.  I fixed the bug.