### PR TITLE
Replace deprecated `default_features` with `default-features`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ zip = { version = "2.1.0", optional = true }
 winreg = "0.52.0"
 
 [dev-dependencies]
-chrono = { version = "0.4", default_features = false, features = ["clock"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 env_logger = "0.11.3"
 filepath = "0.1.2"
-jpeg-decoder = { version = "0.3", default_features = false }
+jpeg-decoder = { version = "0.3", default-features = false }
 png = { version = "0.17" }
 tiny_http = "0.12"
 


### PR DESCRIPTION
I compiled the crate and found a warning complaining about an obsolete use of `deafult_features`:

```
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `chrono` dependency)
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `jpeg-decoder` dependency)
```

so I fixed it.