### PR TITLE
Added devtools to launch options

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -91,6 +91,10 @@ pub struct LaunchOptions<'a> {
     #[builder(default = "true")]
     pub sandbox: bool,
 
+    /// Automatically open devtools for tabs. Forces headless to be false
+    #[builder(default = "true")]
+    pub devtools: bool,
+
     /// Determines whether to enable GPU or not. Default to false.
     #[builder(default = "false")]
     pub enable_gpu: bool,
@@ -172,6 +176,7 @@ impl<'a> Default for LaunchOptions<'a> {
     fn default() -> Self {
         LaunchOptions {
             headless: true,
+            devtools: false,
             sandbox: true,
             enable_gpu: false,
             enable_logging: false,
@@ -348,8 +353,10 @@ impl Process {
             args.extend([window_size_option.as_str()]);
         }
 
-        if launch_options.headless {
+        if launch_options.headless && !launch_options.devtools {
             args.extend(["--headless"]);
+        } else if launch_options.devtools {
+            args.extend(["--auto-open-devtools-for-tabs"]);
         }
 
         if launch_options.ignore_certificate_errors {

--- a/src/util.rs
+++ b/src/util.rs
@@ -69,7 +69,7 @@ impl Wait {
 
     pub fn forever() -> Self {
         Self {
-            timeout: Duration::from_secs(u64::max_value()),
+            timeout: Duration::from_secs(u64::MAX),
             ..Self::default()
         }
     }


### PR DESCRIPTION
- Fix: when having a `add_event_listener` and `headless=false` and `devtools` is open (manually opened or via arguments), it will crash due to the error: `got TargetInfoChanged event about a tab not in our list`. Chromium opens a new tab and triggers: Event TargetCreated type=‘other’ with empty url field. Next the Event::TargetInfoChanged and the tab with type other does not exists in our tracked tabs list.
- Add: launcher option `devtools`, it forces headless to be `false`. Make sure its the same behaviour as Puppeteer.

@ maintainers: Do we want to track devtools tabs? Currently I skip the devtool tabs to be tracked.