### PR TITLE
add `ignore_default_args` to launch options

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -141,6 +141,10 @@ pub struct LaunchOptions<'a> {
     #[builder(default)]
     pub args: Vec<&'a OsStr>,
 
+    /// Ignore a default given flag
+    #[builder(default)]
+    pub ignore_default_args: Vec<&'a OsStr>,
+
     /// Disable default arguments
     #[builder(default)]
     pub disable_default_args: bool,
@@ -186,6 +190,7 @@ impl<'a> Default for LaunchOptions<'a> {
             #[cfg(feature = "fetch")]
             fetcher_options: Default::default(),
             args: Vec::new(),
+            ignore_default_args: Vec::new(),
             disable_default_args: false,
             proxy_server: None,
         }
@@ -332,7 +337,18 @@ impl Process {
         ];
 
         if !launch_options.disable_default_args {
-            args.extend(DEFAULT_ARGS);
+            let ignore_default_args: Vec<&str> = launch_options
+                .ignore_default_args
+                .iter()
+                .map(|arg| arg.to_str().unwrap())
+                .collect();
+
+            let defaults: Vec<_> = DEFAULT_ARGS
+                .iter()
+                .filter(|arg| !ignore_default_args.contains(arg))
+                .collect();
+
+            args.extend(defaults);
         }
 
         if !launch_options.args.is_empty() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -69,7 +69,7 @@ impl Wait {
 
     pub fn forever() -> Self {
         Self {
-            timeout: Duration::from_secs(u64::max_value()),
+            timeout: Duration::from_secs(u64::MAX),
             ..Self::default()
         }
     }


### PR DESCRIPTION
Implemented launch option `ignore_default_args` same as what Puppeteer has implemented.
This is useful for excluding default arguments, such as ignoring: `--enable-automation`

For example: [puppeteer/docs/troubleshooting.md at main · puppeteer/puppeteer](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-doesnt-launch-on-windows)