### PR TITLE
[Fix] Fix mismatched default value in `LaunchOptions`

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -92,7 +92,7 @@ pub struct LaunchOptions<'a> {
     pub sandbox: bool,
 
     /// Automatically open devtools for tabs. Forces headless to be false
-    #[builder(default = "true")]
+    #[builder(default = "false")]
     pub devtools: bool,
 
     /// Determines whether to enable GPU or not. Default to false.


### PR DESCRIPTION
See https://github.com/rust-headless-chrome/rust-headless-chrome/issues/500 for more information.

Successfully merging this will close #500.