### PR TITLE
Fixes wrong error message when running as root in sandbox mode

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -270,6 +270,13 @@ impl Process {
                 }
                 Err(error) => {
                     trace!("Problem getting WebSocket URL from Chrome: {}", error);
+
+                    if let Some(&ChromeLaunchError::RunningAsRootWithoutNoSandbox) =
+                        error.downcast_ref::<ChromeLaunchError>()
+                    {
+                        return Err(error);
+                    }
+
                     if launch_options.port.is_none() {
                         process = Self::start_process(&launch_options)?;
                     } else {


### PR DESCRIPTION
I was using the latest version of `rust-headless-chrome` when I got the following error
![image](https://github.com/user-attachments/assets/bd00b251-5561-42a5-877b-bb18977f5c93)

But there were no other apps occupying these ports on the server!

So I looked into the repo, and found the real error
![image](https://github.com/user-attachments/assets/df81190b-3952-4d6b-b826-21676e91c139)

I found the [PR where fcoury committed the code](https://github.com/rust-headless-chrome/rust-headless-chrome/pull/406)

It worked, managed to detect sandbox issues, but failed to check if the error is a `RunningAsRootWithoutNoSandbox` error.
I guess the check was missing because the other enum values of `ChromeLaunchError` are all about port issues.
So I'd like to add the logic to avoid misleading people encountered the same issue as me.

After the change, the error message would be 
![image](https://github.com/user-attachments/assets/6cdae970-69b5-4157-9fd1-3a461bf09876)

This change passed `cargo check` on my machine.

