### PR TITLE
Add get_ws_url to expose ws url

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -177,6 +177,13 @@ impl Browser {
         self.inner.process.as_ref().map(process::Process::get_id)
     }
 
+    pub fn get_ws_url(&self) -> String {
+        match &self.inner.process {
+            None => "browser is not running".to_string(),
+            Some(process) => process.debug_ws_url.clone().to_string(),
+        }
+    }
+
     /// The tabs are behind an `Arc` and `Mutex` because they're accessible from multiple threads
     /// (including the one that handles incoming protocol events about new or changed tabs).
     pub fn get_tabs(&self) -> &Arc<Mutex<Vec<Arc<Tab>>>> {


### PR DESCRIPTION
Sometimes we need to deploy webdriver separately, so added a method to expose the deployment address.