### PR TITLE
chore: remove unnecessary println

### DIFF
--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -220,8 +220,6 @@ impl Fetcher {
         )
         .map_err(|_err| anyhow!("Could not create directory at {:?}", path.parent()))?;
 
-        println!("{path:?}");
-
         info!("Creating file for download: {}", &path.display());
         let mut file = OpenOptions::new()
             .create(true)


### PR DESCRIPTION
Use `info!` instead of `println` if needed