### PR TITLE
Use max frame size and message size for web socket connections

### DIFF
--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -155,7 +155,12 @@ impl WebSocketConnection {
     )> {
         let mut client = tungstenite::client::connect_with_config(
             ws_url.as_str(),
-            Some(WebSocketConfig::default().accept_unmasked_frames(true)),
+            Some(
+                WebSocketConfig::default()
+                    .accept_unmasked_frames(true)
+                    .max_message_size(None)
+                    .max_frame_size(None),
+            ),
             u8::MAX - 1,
         )?;
 


### PR DESCRIPTION
Resolves #436 and #385

This was added in #386 and #439, but somehow it gets reverted in #539