### PR TITLE
feat(browser): Add callback functionality when creating a tab

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -180,6 +180,9 @@ pub struct LaunchOptions<'a> {
     /// The callback executed when creating a Tab.
     #[builder(default = "None")]
     pub on_tab_created: Option<fn(tab: Arc<Tab>)>,
+
+    #[builder(default = "None")]
+    pub on_browser_closed: Option<fn()>,
 }
 
 impl Default for LaunchOptions<'_> {
@@ -205,6 +208,7 @@ impl Default for LaunchOptions<'_> {
             disable_default_args: false,
             proxy_server: None,
             on_tab_created: None,
+            on_browser_closed: None,
         }
     }
 }

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -178,6 +178,7 @@ pub struct LaunchOptions<'a> {
     pub proxy_server: Option<&'a str>,
 
     /// The callback executed when creating a Tab.
+    #[builder(default = "None")]
     pub on_tab_created: Option<fn(tab: Arc<Tab>)>,
 }
 

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -4,6 +4,7 @@ use std::{
     io::{BufRead, BufReader, prelude::*},
     net,
     process::{Child, Command, Stdio},
+    sync::Arc,
     time::Duration,
 };
 
@@ -26,6 +27,7 @@ use winreg::{RegKey, enums::HKEY_LOCAL_MACHINE};
 use crate::browser::default_executable;
 use crate::util;
 
+use super::Tab;
 #[cfg(feature = "fetch")]
 use super::fetcher::{Fetcher, FetcherOptions};
 use std::collections::HashMap;
@@ -174,6 +176,9 @@ pub struct LaunchOptions<'a> {
     /// Setup the proxy server for headless chrome instance
     #[builder(default = "None")]
     pub proxy_server: Option<&'a str>,
+
+    /// The callback executed when creating a Tab.
+    pub on_tab_created: Option<fn(tab: Arc<Tab>)>,
 }
 
 impl Default for LaunchOptions<'_> {
@@ -198,6 +203,7 @@ impl Default for LaunchOptions<'_> {
             ignore_default_args: Vec::new(),
             disable_default_args: false,
             proxy_server: None,
+            on_tab_created: None,
         }
     }
 }

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -451,7 +451,7 @@ impl Process {
 
         let process = TemporaryProcess(
             command.args(&args).stderr(Stdio::piped()).spawn()?,
-            temp_user_data_dir,
+            temp_user_data_dir
         );
         Ok(process)
     }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,6 +1,5 @@
 #![allow(unused_variables)]
 
-use std::any::Any;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, Instant};

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,5 +1,6 @@
 #![allow(unused_variables)]
 
+use std::any::Any;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
@@ -45,10 +46,15 @@ fn browser() -> Browser {
     Browser::new(
         LaunchOptionsBuilder::default()
             .headless(true)
+            .on_tab_created(Some(on_tab_created))
             .build()
             .unwrap(),
     )
     .unwrap()
+}
+
+fn on_tab_created(tab: Arc<Tab>) {
+    println!("new tab: {:?}", tab.get_target_id());
 }
 
 fn dumb_client(server: &server::Server) -> (Browser, Arc<Tab>) {

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -46,6 +46,7 @@ fn browser() -> Browser {
         LaunchOptionsBuilder::default()
             .headless(true)
             .on_tab_created(Some(on_tab_created))
+            .on_browser_closed(Some(on_browser_cloesed))
             .build()
             .unwrap(),
     )
@@ -54,6 +55,10 @@ fn browser() -> Browser {
 
 fn on_tab_created(tab: Arc<Tab>) {
     println!("new tab: {:?}", tab.get_target_id());
+}
+
+fn on_browser_cloesed() {
+    println!("browser closed");
 }
 
 fn dumb_client(server: &server::Server) -> (Browser, Arc<Tab>) {


### PR DESCRIPTION
The   on_tab_created   callback function has been added to the browser module, which is triggered when a new tab is created. This feature allows users to perform custom operations when a tab is created, enhancing the extensibility and flexibility of the application layer.

Users can implement a global tab creation callback by passing the   on_tab_created   function when constructing the browser object.